### PR TITLE
Bugfix reuse of global RegEx object.

### DIFF
--- a/lib/hacks/gradient.js
+++ b/lib/hacks/gradient.js
@@ -125,6 +125,10 @@ class Gradient extends Value {
         if (params[0].value === 'to') {
             return params;
         }
+        /* reset the search index of the global regex object, otherwise the next use 
+         * will start the search for a match at the index where the search ended this time.
+         */
+        isDirection.lastIndex = 0;
         if (!isDirection.test(params[0].value)) {
             return params;
         }


### PR DESCRIPTION
When the same global regex object is used, you need to reset the lastIndex property.